### PR TITLE
Fix default timeout values

### DIFF
--- a/jobs/cf-performance-tests/spec
+++ b/jobs/cf-performance-tests/spec
@@ -30,9 +30,9 @@ properties:
   samples:
     default: 5
   basic_timeout:
-    default: "60s"
+    default: 60
   long_timeout:
-    default: "180s"
+    default: 180
   ginkgo_timeout:
     default: "3h"
   users:


### PR DESCRIPTION
Update of viper changed how the config values are being interpret. The provided and default values must now be without 's'.